### PR TITLE
Intruduced basic CMake configuration

### DIFF
--- a/BoostUtilityConfig.cmake
+++ b/BoostUtilityConfig.cmake
@@ -1,0 +1,13 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(CMakeFindDependencyMacro)
+find_dependency(BoostConfig 1.66)
+find_dependency(BoostCore 1.66)
+find_dependency(BoostStaticAssert 1.66)
+find_dependency(BoostMpl 1.66)
+find_dependency(BoostPreprocessor 1.66)
+find_dependency(BoostTypeTraits 1.66)
+find_dependency(BoostThrowException 1.66)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostUtilityTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(BoostUtility VERSION 1.66 LANGUAGES CXX)
+
+add_library(utility INTERFACE)
+
+target_include_directories(utility INTERFACE 
+    $<BUILD_INTERFACE:${BoostUtility_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${BoostUtility_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
+find_package(BoostConfig 1.66 REQUIRED)
+find_package(BoostCore 1.66 REQUIRED)
+find_package(BoostStaticAssert 1.66 REQUIRED)
+find_package(BoostMpl 1.66 REQUIRED)
+find_package(BoostPreprocessor 1.66 REQUIRED)
+find_package(BoostTypeTraits 1.66 REQUIRED)
+find_package(BoostThrowException 1.66 REQUIRED)
+
+target_link_libraries(utility
+    INTERFACE
+        Boost::config
+        Boost::core
+        Boost::static_assert
+        Boost::mpl
+        Boost::preprocessor
+        Boost::type_traits
+        Boost::throw_exception
+    )
+
+install(EXPORT utility-targets
+    FILE BoostUtilityTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS utility EXPORT utility-targets
+    INCLUDES DESTINATION include
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostUtilityConfigVersion.cmake"
+    VERSION ${BoostUtility_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostUtilityConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostUtilityConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+install(DIRECTORY include/ DESTINATION include)
+
+add_library(Boost::utility ALIAS utility)


### PR DESCRIPTION
Expresses Boost::utility as an `INTERFACE` library in CMake.
- use via `add_subdirectory` 
- use via `find_package(BoostUtility 1.66)` if previously installed. This is achieved via the following install:
```
$INSTALL_PREFIX
├── include
│   └── boost
│       ├── call_traits.hpp
│       ├── compressed_pair.hpp
│       ├── detail
│       │   ├── call_traits.hpp
│       │   ├── compressed_pair.hpp
│       │   └── ob_compressed_pair.hpp
│       ├── operators.hpp
│       ├── operators_v1.hpp
│       ├── utility
│       │   ├── base_from_member.hpp
│       │   ├── binary.hpp
│       │   ├── compare_pointees.hpp
│       │   ├── detail
│       │   │   ├── in_place_factory_prefix.hpp
│       │   │   ├── in_place_factory_suffix.hpp
│       │   │   └── result_of_iterate.hpp
│       │   ├── identity_type.hpp
│       │   ├── in_place_factory.hpp
│       │   ├── result_of.hpp
│       │   ├── string_ref_fwd.hpp
│       │   ├── string_ref.hpp
│       │   ├── string_view_fwd.hpp
│       │   ├── string_view.hpp
│       │   ├── typed_in_place_factory.hpp
│       │   └── value_init.hpp
│       └── utility.hpp
└── lib
    └── cmake
        └── boost
            ├── BoostUtilityConfig.cmake
            ├── BoostUtilityConfigVersion.cmake
            └── BoostUtilityTargets.cmake

8 directories, 26 files
```
- tests are __not__ included in the build